### PR TITLE
UPBGE: Use the up-to-date dshow format instead of death vfwcap format (Merge Pull Request)

### DIFF
--- a/source/gameengine/VideoTexture/VideoFFmpeg.cpp
+++ b/source/gameengine/VideoTexture/VideoFFmpeg.cpp
@@ -173,9 +173,14 @@ int VideoFFmpeg::openStream(const char *filename, AVInputFormat *inputFormat, AV
 	AVCodec         *codec;
 	AVCodecContext  *codecCtx;
 
-	if (avformat_open_input(&formatCtx, filename, inputFormat, formatParams) != 0) {
-		return -1;
-	}
+    if (avformat_open_input(&formatCtx, filename, inputFormat, formatParams) != 0) {
+        if (avformat_open_input(&formatCtx, filename, inputFormat, nullptr) != 0) {
+            return -1;
+        }
+        else {
+            std::cout << "Camera capture: Format not compatible. Capture in default camera format" << std::endl;
+        }
+    }
 
 	if (avformat_find_stream_info(formatCtx, nullptr) < 0) {
 		avformat_close_input(&formatCtx);
@@ -581,12 +586,12 @@ void VideoFFmpeg::openCam(char *file, short camIdx)
 
 #ifdef WIN32
 	// video capture on windows only through Video For Windows driver
-	inputFormat = av_find_input_format("vfwcap");
+    inputFormat = av_find_input_format("dshow");
 	if (!inputFormat) {
 		// Video For Windows not supported??
 		return;
 	}
-	sprintf(filename, "%d", camIdx);
+    sprintf(filename, "video=%s", file);
 #else
 	// In Linux we support two types of devices: VideoForLinux and DV1394.
 	// the user specify it with the filename:


### PR DESCRIPTION
This way we can capture high resolutions from Camera under Windows.

Additionally a fallback format is introduced. With this change whether
the format introduced is not compatible with
the camera specs then UPBGE captures in the default camera format
avoiding black screens.

Thanks to @youle31 and @nestanqueiro for testing